### PR TITLE
Add <time> semantics to tabular data

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -247,3 +247,8 @@ footer{
 #chapter-11 table td{
 	vertical-align: top;
 }
+
+#chapter-11 table th{
+	text-align: left;
+	font-weight: normal;
+}

--- a/src/epub/text/chapter-11.xhtml
+++ b/src/epub/text/chapter-11.xhtml
@@ -163,22 +163,16 @@
 			<p>“I have secured certain information, my lord, which I have duly noted. Total expenditure on beer for self and witnesses 7<abbr>s.</abbr> 2<abbr>d.</abbr>, my lord.”</p>
 			<p>Lord Peter paid the 7<abbr>s.</abbr> 2<abbr>d.</abbr> without a word, and they adjourned to the Rose and Crown. Being accommodated in a private parlor, and having ordered lunch, they proceeded to draw up the following schedule:</p>
 			<table>
-				<thead>
+				<caption>
+					<b>Grimethorpe’s Movements.</b>
+				</caption>
+				<tbody>
 					<tr>
 						<th colspan="2">
 							<p>
-								<b>Grimethorpe’s Movements.</b>
-							</p>
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td colspan="2">
-							<p>
 								<i>October 13th:</i>
 							</p>
-						</td>
+						</th>
 					</tr>
 					<tr>
 						<td>
@@ -265,15 +259,13 @@
 						</td>
 					</tr>
 				</tbody>
-			</table>
-			<table>
 				<tbody>
 					<tr>
-						<td colspan="2">
+						<th colspan="2">
 							<p>
 								<i>October 14th:</i>
 							</p>
-						</td>
+						</th>
 					</tr>
 					<tr>
 						<td>

--- a/src/epub/text/chapter-11.xhtml
+++ b/src/epub/text/chapter-11.xhtml
@@ -170,13 +170,13 @@
 					<tr>
 						<th colspan="2">
 							<p>
-								<i>October 13th:</i>
+								<i><time datetime="10-13">October 13th</time>:</i>
 							</p>
 						</th>
 					</tr>
 					<tr>
 						<td>
-							<p>12:30 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="12:30">12:30 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Arrives Rose and Crown.</p>
@@ -184,7 +184,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>1:00 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="13:00">1:00 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Lunches.</p>
@@ -192,19 +192,19 @@
 					</tr>
 					<tr>
 						<td>
-							<p>3:00 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="15:00">3:00 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>Orders two drills from man called Gooch in Trimmer’s Lane.</td>
 					</tr>
 					<tr>
 						<td>
-							<p>4:30 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="16:30">4:30 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>Drink with Gooch to clinch bargain.</td>
 					</tr>
 					<tr>
 						<td>
-							<p>5:00 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="17:00">5:00 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Calls at house of John Watson carrier, about delivering some dog-food. Watson absent. <abbr epub:type="z3998:name-title">Mrs.</abbr> Watson says <abbr epub:type="z3998:surname">W.</abbr> expected back that night. <abbr epub:type="z3998:surname">G.</abbr> says will call again.</p>
@@ -212,7 +212,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>5:30 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="17:30">5:30 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Calls on Mark Dolby, grocer, to complain about some tinned salmon.</p>
@@ -220,7 +220,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>5:45 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="17:45">5:45 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Calls on <abbr epub:type="z3998:name-title">Mr.</abbr> Hewitt, optician, to pay bill for spectacles and dispute the amount.</p>
@@ -228,7 +228,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>6:00 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="18:00">6:00 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Drinks with Zedekiah Bone at Bridge and Bottle.</p>
@@ -236,7 +236,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>6:45 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="18:45">6:45 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Calls again on <abbr epub:type="z3998:name-title">Mrs.</abbr> Watson. Watson not yet home.</p>
@@ -244,7 +244,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>7:00 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="19:00">7:00 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Seen by Constable Z15 drinking with several men at Pig and Whistle. Heard to use threatening language with regard to some person unknown.</p>
@@ -252,7 +252,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>7:20 <abbr class="eoc">p.m.</abbr></p>
+							<p><time datetime="19:20">7:20 <abbr class="eoc">p.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Seen to leave Pig and Whistle with two men (not yet identified).</p>
@@ -263,13 +263,13 @@
 					<tr>
 						<th colspan="2">
 							<p>
-								<i>October 14th:</i>
+								<i><time datetime="10-14">October 14th</time>:</i>
 							</p>
 						</th>
 					</tr>
 					<tr>
 						<td>
-							<p>1:15 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="01:15">1:15 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Picked up by Watson, carrier, about a mile out on road to Riddlesdale, very dirty and ill-tempered, and not quite sober.</p>
@@ -277,7 +277,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>1:45 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="01:45">1:45 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Let into Rose and Crown by James Johnson, potman.</p>
@@ -285,7 +285,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>9:00 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="09:00">9:00 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Called by Elizabeth Dobbin.</p>
@@ -293,7 +293,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>9:30 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="09:30">9:30 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>In Bar of Rose and Crown. Hears of man murdered at Riddlesdale. Behaves suspiciously.</p>
@@ -301,7 +301,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>10:15 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="10:15">10:15 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Cashes check £129 17<abbr>s.</abbr> 8<abbr>d.</abbr> at Lloyds Bank.</p>
@@ -309,7 +309,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>10:30 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="10:30">10:30 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Pays Gooch for drills.</p>
@@ -317,7 +317,7 @@
 					</tr>
 					<tr>
 						<td>
-							<p>11:05 <abbr class="eoc">a.m.</abbr></p>
+							<p><time datetime="11:05">11:05 <abbr class="eoc">a.m.</abbr></time></p>
 						</td>
 						<td>
 							<p>Leaves Rose and Crown for Grider’s Hole.</p>


### PR DESCRIPTION
This tweaks the tables a bit:

- Combines two adjacent tables into one with two `<tbody>`
- Moves table title from a `<th>` to `<caption>`
- Moves the dates (one per `<tbody>`) from `<td>` to `<th>`